### PR TITLE
[Step1] feat : 문자열 사칙 연산 계산기 구현

### DIFF
--- a/src/main/java/string_calculator/Operator.java
+++ b/src/main/java/string_calculator/Operator.java
@@ -1,0 +1,64 @@
+package string_calculator;
+
+public enum Operator {
+    ADD {
+        @Override
+        public int operate(int a, int b) {
+            return a + b;
+        }
+    },
+    SUBTRACT {
+        @Override
+        public int operate(int a, int b) {
+            return a - b;
+        }
+    },
+    MULTIPLY {
+        @Override
+        public int operate(int a, int b) {
+            return a * b;
+        }
+    },
+    DIVIDE {
+        @Override
+        public int operate(int a, int b) {
+            return a / b;
+        }
+    };
+
+    private static final String ILLEGAL_ARGUMENT_ERROR_MESSAGE = "사칙연산 기호가 아닙니다.";
+    private static final char ADD_CHAR = '+';
+    private static final char SUBTRACT_CHAR = '-';
+    private static final char MULTIPLY_CHAR = '*';
+    private static final char DIVIDE_CHAR = '/';
+
+    public abstract int operate(int a, int b);
+
+    public static Operator from(char opChar) {
+        if (opChar == ADD_CHAR) {
+            return ADD;
+        }
+
+        if (opChar == SUBTRACT_CHAR) {
+            return SUBTRACT;
+        }
+
+        if (opChar == MULTIPLY_CHAR) {
+            return MULTIPLY;
+        }
+
+        if (opChar == DIVIDE_CHAR) {
+            return DIVIDE;
+        }
+
+        throw new IllegalArgumentException(ILLEGAL_ARGUMENT_ERROR_MESSAGE);
+    }
+
+    public static Operator from(String opString) {
+        if (opString.length() > 1) {
+            throw new IllegalArgumentException(ILLEGAL_ARGUMENT_ERROR_MESSAGE);
+        }
+
+        return from(opString.charAt(0));
+    }
+}

--- a/src/main/java/string_calculator/StringCalculator.java
+++ b/src/main/java/string_calculator/StringCalculator.java
@@ -1,0 +1,50 @@
+package string_calculator;
+
+public class StringCalculator {
+    private static final String ILLEGAL_ARGUMENT_ERROR_MESSAGE = "입력 값이 알맞지 않습니다.";
+    private static final String DEFAULT_DELIMITER = " ";
+
+    public static int splitAndCalculate(String input) {
+        if (isBlank(input)) {
+            throw new IllegalArgumentException(ILLEGAL_ARGUMENT_ERROR_MESSAGE);
+        }
+        String[] tokens = split(input);
+        return calculateWithTokens(tokens);
+    }
+
+    private static boolean isBlank(String input) {
+        if (input == null) {
+            return true;
+        }
+
+        return input.isBlank();
+    }
+
+    private static String[] split(String input) {
+        String[] tokens = input.split(DEFAULT_DELIMITER);
+
+        if (tokens.length % 2 == 0) {
+            throw new IllegalArgumentException(ILLEGAL_ARGUMENT_ERROR_MESSAGE);
+        }
+
+        return tokens;
+    }
+
+    private static int toInt(String input) {
+        try {
+            return Integer.parseInt(input);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(ILLEGAL_ARGUMENT_ERROR_MESSAGE);
+        }
+    }
+
+    private static int calculateWithTokens(String[] tokens) {
+        int result = toInt(tokens[0]);
+        for (int i = 1; i < tokens.length; i += 2) {
+            Operator operator = Operator.from(tokens[i]);
+            int num = toInt(tokens[i + 1]);
+            result = operator.operate(result, num);
+        }
+        return result;
+    }
+}

--- a/src/test/java/string_calculator/OperatorTest.java
+++ b/src/test/java/string_calculator/OperatorTest.java
@@ -1,0 +1,70 @@
+package string_calculator;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class OperatorTest {
+    @ParameterizedTest(name = "{0}으로 {1}을 만들 수 있다")
+    @MethodSource("getInputFor_사칙연산_기호_char로_enum_객체를_만들_수_있다")
+    void 사칙연산_기호_char로_enum_객체를_만들_수_있다(char c, Operator operator) {
+        assertThat(Operator.from(c)).isEqualTo(operator);
+    }
+
+    @ParameterizedTest(name = "{0}으로 {1}을 만들 수 있다")
+    @MethodSource("getInputFor_사칙연산_기호_String으로_enum_객체를_만들_수_있다")
+    void 사칙연산_기호_string으로_enum_객체를_만들_수_있다(String s, Operator operator) {
+        assertThat(Operator.from(s)).isEqualTo(operator);
+    }
+
+    @ParameterizedTest(name = "{0}은 {1}과 {2}로 할당된 연산을 할 수 있고 결과는 {3}이다.")
+    @MethodSource("getInputFor_할당된_사칙연산을_수행할_수_있다")
+    void 할당된_사칙연산을_수행할_수_있다(Operator operator, int input1, int input2, int expected) {
+        assertThat(operator.operate(input1, input2)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest(name = "{0}이 주어지면 적절한 기호가 아니므로 예외가 발생한다.")
+    @ValueSource(chars = {'a', '가', '1', '_', 'X', ' ', '$'})
+    void 사칙연산_기호_char가_아니면_예외가_발생한다(char notOpChar) {
+        assertThatThrownBy(() -> Operator.from(notOpChar)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest(name = "{0}이 주어지면 적절한 기호가 아니므로 예외가 발생한다.")
+    @ValueSource(strings = {"ADD", "6", "++", "-*", "-8"})
+    void 사칙연산_기호_string이_아니면_예외가_발생한다(String notOpString) {
+        assertThatThrownBy(() -> Operator.from(notOpString)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static Stream<Arguments> getInputFor_사칙연산_기호_char로_enum_객체를_만들_수_있다() {
+        return Stream.of(
+                Arguments.arguments('+', Operator.ADD),
+                Arguments.arguments('-', Operator.SUBTRACT),
+                Arguments.arguments('*', Operator.MULTIPLY),
+                Arguments.arguments('/', Operator.DIVIDE)
+        );
+    }
+
+    private static Stream<Arguments> getInputFor_사칙연산_기호_String으로_enum_객체를_만들_수_있다() {
+        return Stream.of(
+                Arguments.arguments("+", Operator.ADD),
+                Arguments.arguments("-", Operator.SUBTRACT),
+                Arguments.arguments("*", Operator.MULTIPLY),
+                Arguments.arguments("/", Operator.DIVIDE)
+        );
+    }
+
+    private static Stream<Arguments> getInputFor_할당된_사칙연산을_수행할_수_있다() {
+        return Stream.of(
+                Arguments.arguments(Operator.ADD, 1, 2, 3),
+                Arguments.arguments(Operator.SUBTRACT, 4, 3, 1),
+                Arguments.arguments(Operator.MULTIPLY, 3, 4, 12),
+                Arguments.arguments(Operator.DIVIDE, 10, 3, 3)
+        );
+    }
+}

--- a/src/test/java/string_calculator/StringCalculatorTest.java
+++ b/src/test/java/string_calculator/StringCalculatorTest.java
@@ -1,0 +1,33 @@
+package string_calculator;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class StringCalculatorTest {
+    @ParameterizedTest(name = "{0}이 주어지면 결과는 {1}이다.")
+    @CsvSource(value = {"2 + 3 * 4 / 2:10", "1 + 3:4", "5 - 2 / 3:1", "6 * 2 * 4:48", "3 + 3 + 3 + 1 / 3:3"}, delimiter = ':')
+    void 문자열로_주어진_사칙연산을_할_수_있다(String input, int expected) {
+        assertThat(StringCalculator.splitAndCalculate(input)).isEqualTo(expected);
+    }
+
+    @Test
+    void 입력_값이_null이면_예외가_발생한다() {
+        assertThatThrownBy(() -> StringCalculator.splitAndCalculate(null)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 입력_값이_공백이면_예외가_발생한다() {
+        assertThatThrownBy(() -> StringCalculator.splitAndCalculate("")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest(name = "{0}이 주어지면 예외가 발생한다")
+    @ValueSource(strings = {"2+3 * 4 / 2", "1 +3", "5 - 2 // 3", "6 * 2 * 4 가", "3 3 3 3 3 + 1"})
+    void 알맞지_않은_입력이_주어지면_예외가_발생한다(String input) {
+        assertThatThrownBy(() -> StringCalculator.splitAndCalculate(input)).isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
안녕하세요.
문자열 사칙 연산 계산기 구현 미션 완료하여 PR 드립니다.
잘 부탁드립니다.

**기능 요구사항**
- 사용자가 입력한 문자열 값에 따라 사칙연산을 수행할 수 있는 계산기를 구현해야 한다.
- 입력 문자열의 숫자와 사칙 연산 사이에는 반드시 빈 공백 문자열이 있다고 가정한다.
- 나눗셈의 경우 결과 값을 정수로 떨어지는 값으로 한정한다.
- 문자열 계산기는 사칙연산의 계산 우선순위가 아닌 입력 값에 따라 계산 순서가 결정된다. 즉, 수학에서는 곱셈, 나눗셈이 덧셈, 뺄셈 보다 먼저 계산해야 하지만 이를 무시한다.
- 예를 들어 2 + 3 * 4 / 2와 같은 문자열을 입력할 경우 2 + 3 * 4 / 2 실행 결과인 10을 출력해야 한다.
