### PR TITLE
Step 2 : 로또 수동 구현

### DIFF
--- a/src/main/java/lotto/controller/LottoController.java
+++ b/src/main/java/lotto/controller/LottoController.java
@@ -2,6 +2,7 @@ package lotto.controller;
 
 import lotto.domain.Ball;
 import lotto.domain.BoughtLottos;
+import lotto.domain.BoughtResult;
 import lotto.domain.Lotto;
 import lotto.domain.LottoGenerator;
 import lotto.domain.LottoResults;
@@ -30,7 +31,8 @@ public class LottoController {
     public void startLotto() {
         Money money = lottoReader.readMoney();
 
-        BoughtLottos boughtLottos = lottoGenerator.generate(money);
+        BoughtResult boughtResult = lottoGenerator.generate(money);
+        BoughtLottos boughtLottos = boughtResult.getBoughtLottos();
         lottoWriter.printBoughtLottos(boughtLottos);
 
         Lotto winningBalls = lottoReader.readWinningLotto();

--- a/src/main/java/lotto/controller/LottoController.java
+++ b/src/main/java/lotto/controller/LottoController.java
@@ -1,8 +1,10 @@
 package lotto.controller;
 
+import java.util.List;
 import lotto.domain.Ball;
 import lotto.domain.BoughtLottos;
 import lotto.domain.BoughtResult;
+import lotto.domain.Count;
 import lotto.domain.Lotto;
 import lotto.domain.LottoGenerator;
 import lotto.domain.LottoResults;
@@ -30,9 +32,14 @@ public class LottoController {
 
     public void startLotto() {
         Money money = lottoReader.readMoney();
+        Count count = lottoReader.readCount();
+        List<Lotto> manualLottos = lottoReader.readManualLottos(count);
+        BoughtResult manualBoughtResult = lottoGenerator.generateManually(money, manualLottos);
 
-        BoughtResult boughtResult = lottoGenerator.generate(money);
-        BoughtLottos boughtLottos = boughtResult.getBoughtLottos();
+        BoughtResult boughtResult = lottoGenerator.generate(manualBoughtResult.getChange());
+
+        BoughtLottos boughtLottos = BoughtLottos.merge(
+                manualBoughtResult.getBoughtLottos(), boughtResult.getBoughtLottos());
         lottoWriter.printBoughtLottos(boughtLottos);
 
         Lotto winningBalls = lottoReader.readWinningLotto();

--- a/src/main/java/lotto/controller/LottoController.java
+++ b/src/main/java/lotto/controller/LottoController.java
@@ -32,7 +32,7 @@ public class LottoController {
 
     public void startLotto() {
         Money money = lottoReader.readMoney();
-        Count count = lottoReader.readCount();
+        Count count = lottoReader.readCount(money);
         List<Lotto> manualLottos = lottoReader.readManualLottos(count);
         BoughtResult manualBoughtResult = lottoGenerator.generateManually(money, manualLottos);
 

--- a/src/main/java/lotto/domain/BoughtLottos.java
+++ b/src/main/java/lotto/domain/BoughtLottos.java
@@ -1,16 +1,15 @@
 package lotto.domain;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class BoughtLottos {
 
-    private final int count;
     private final List<Lotto> lottos;
 
     public BoughtLottos(final List<Lotto> lottos) {
-        this.count = lottos.size();
-        this.lottos = lottos;
+        this.lottos = new ArrayList<>(lottos);
     }
 
     public LottoResults winningResults(final WinningLotto winningLotto) {
@@ -19,8 +18,16 @@ public class BoughtLottos {
                 .collect(Collectors.toList()));
     }
 
+    public static BoughtLottos merge(final BoughtLottos b1, final BoughtLottos b2) {
+        final BoughtLottos merged = new BoughtLottos(b1.lottos);
+
+        merged.lottos.addAll(b2.lottos);
+
+        return merged;
+    }
+
     public int getCount() {
-        return this.count;
+        return this.lottos.size();
     }
 
     public List<Lotto> getLottos() {

--- a/src/main/java/lotto/domain/BoughtResult.java
+++ b/src/main/java/lotto/domain/BoughtResult.java
@@ -1,0 +1,20 @@
+package lotto.domain;
+
+public class BoughtResult {
+
+    private final Money change;
+    private final BoughtLottos boughtLottos;
+
+    public BoughtResult(Money change, BoughtLottos boughtLottos) {
+        this.change = change;
+        this.boughtLottos = boughtLottos;
+    }
+
+    public Money getChange() {
+        return change;
+    }
+
+    public BoughtLottos getBoughtLottos() {
+        return boughtLottos;
+    }
+}

--- a/src/main/java/lotto/domain/Count.java
+++ b/src/main/java/lotto/domain/Count.java
@@ -1,0 +1,37 @@
+package lotto.domain;
+
+public class Count {
+
+    private static final String NUMBER_PATTERN = "\\d+";
+    private static final String NOT_NUMERIC_EXCEPTION_MESSAGE = "숫자만 입력할 수 있습니다.";
+    private static final String NOT_POSITIVE_EXCEPTION_MESSAGE = "1 이상의 수만 입력하실 수 있습니다.";
+
+    private final int value;
+
+    public Count(final int value) {
+        this(String.valueOf(value));
+    }
+
+    public Count(final String value) {
+        validateNumeric(value);
+        validatePositive(Integer.parseInt(value));
+
+        this.value = Integer.parseInt(value);
+    }
+
+    private void validateNumeric(final String value) {
+        if (!value.matches(NUMBER_PATTERN)) {
+            throw new IllegalArgumentException(NOT_NUMERIC_EXCEPTION_MESSAGE);
+        }
+    }
+
+    private void validatePositive(final int value) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(NOT_POSITIVE_EXCEPTION_MESSAGE);
+        }
+    }
+
+    public int getValue() {
+        return value;
+    }
+}

--- a/src/main/java/lotto/domain/Count.java
+++ b/src/main/java/lotto/domain/Count.java
@@ -5,6 +5,7 @@ public class Count {
     private static final String NUMBER_PATTERN = "\\d+";
     private static final String NOT_NUMERIC_EXCEPTION_MESSAGE = "숫자만 입력할 수 있습니다.";
     private static final String NOT_POSITIVE_EXCEPTION_MESSAGE = "0 이상의 수만 입력하실 수 있습니다.";
+    private static final String NOT_ENOUGH_MONEY_EXCEPTION_MESSAGE = "구매 가능 개수를 초과하였습니다.";
 
     private final int value;
 
@@ -19,6 +20,14 @@ public class Count {
         this.value = Integer.parseInt(value);
     }
 
+    public Count(final String value, final Money money) {
+        validateNumeric(value);
+        validatePositive(Integer.parseInt(value));
+        validateEnoughMoney(value, money);
+
+        this.value = Integer.parseInt(value);
+    }
+
     private void validateNumeric(final String value) {
         if (!value.matches(NUMBER_PATTERN)) {
             throw new IllegalArgumentException(NOT_NUMERIC_EXCEPTION_MESSAGE);
@@ -28,6 +37,12 @@ public class Count {
     private void validatePositive(final int value) {
         if (value < 0) {
             throw new IllegalArgumentException(NOT_POSITIVE_EXCEPTION_MESSAGE);
+        }
+    }
+
+    private void validateEnoughMoney(final String value, final Money money) {
+        if (Integer.parseInt(value) * Lotto.PRICE > money.getValue()) {
+            throw new IllegalArgumentException(NOT_ENOUGH_MONEY_EXCEPTION_MESSAGE);
         }
     }
 

--- a/src/main/java/lotto/domain/Count.java
+++ b/src/main/java/lotto/domain/Count.java
@@ -4,7 +4,7 @@ public class Count {
 
     private static final String NUMBER_PATTERN = "\\d+";
     private static final String NOT_NUMERIC_EXCEPTION_MESSAGE = "숫자만 입력할 수 있습니다.";
-    private static final String NOT_POSITIVE_EXCEPTION_MESSAGE = "1 이상의 수만 입력하실 수 있습니다.";
+    private static final String NOT_POSITIVE_EXCEPTION_MESSAGE = "0 이상의 수만 입력하실 수 있습니다.";
 
     private final int value;
 
@@ -26,7 +26,7 @@ public class Count {
     }
 
     private void validatePositive(final int value) {
-        if (value <= 0) {
+        if (value < 0) {
             throw new IllegalArgumentException(NOT_POSITIVE_EXCEPTION_MESSAGE);
         }
     }

--- a/src/main/java/lotto/domain/LottoGenerateStrategy.java
+++ b/src/main/java/lotto/domain/LottoGenerateStrategy.java
@@ -1,9 +1,7 @@
 package lotto.domain;
 
-import java.util.List;
-
 @FunctionalInterface
 public interface LottoGenerateStrategy {
 
-    Lotto generate(final List<Ball> balls);
+    Lotto generate();
 }

--- a/src/main/java/lotto/domain/LottoGenerator.java
+++ b/src/main/java/lotto/domain/LottoGenerator.java
@@ -6,9 +6,8 @@ import java.util.List;
 public class LottoGenerator {
 
     private static final LottoGenerateStrategy RANDOM_GENERATE_STRATEGY = new RandomLottoGenerateStrategy();
-    private static final String NOT_ENOUGHT_MONEY_EXCEPTION_MONEY = "금액이 부족해 구매할 수 없습니다.";
+    private static final String NOT_ENOUGH_MONEY_EXCEPTION_MONEY = "금액이 부족해 구매할 수 없습니다.";
 
-    private final List<Ball> balls;
 
     private static class LottoGeneratorHandler {
 
@@ -17,11 +16,6 @@ public class LottoGenerator {
     }
 
     private LottoGenerator() {
-        this.balls = new ArrayList<>();
-
-        for (int i = Ball.MIN_NUMBER; i <= Ball.MAX_NUMBER; i++) {
-            this.balls.add(new Ball(i));
-        }
     }
 
     public static LottoGenerator getInstance() {
@@ -66,7 +60,7 @@ public class LottoGenerator {
 
     private void validate(final Money money, final Count count) {
         if (money.getValue() < Lotto.PRICE * count.getValue()) {
-            throw new IllegalArgumentException(NOT_ENOUGHT_MONEY_EXCEPTION_MONEY);
+            throw new IllegalArgumentException(NOT_ENOUGH_MONEY_EXCEPTION_MONEY);
         }
     }
 }

--- a/src/main/java/lotto/domain/LottoGenerator.java
+++ b/src/main/java/lotto/domain/LottoGenerator.java
@@ -31,21 +31,21 @@ public class LottoGenerator {
         return generate(money, RANDOM_GENERATE_STRATEGY);
     }
 
-    public BoughtResult generate(final Money money, final int count) {
+    public BoughtResult generate(final Money money, final Count count) {
         return generate(money, count, RANDOM_GENERATE_STRATEGY);
     }
 
     public BoughtResult generate(final Money money, final LottoGenerateStrategy generateStrategy) {
         final int count = money.getValue() / Lotto.PRICE;
 
-        return generate(money, count, generateStrategy);
+        return generate(money, new Count(count), generateStrategy);
     }
 
-    public BoughtResult generate(final Money money, final int count, final LottoGenerateStrategy generateStrategy) {
+    public BoughtResult generate(final Money money, final Count count, final LottoGenerateStrategy generateStrategy) {
         final List<Lotto> boughtLottos = new ArrayList<>();
-        final Money spent = new Money(Lotto.PRICE * count);
+        final Money spent = new Money(Lotto.PRICE * count.getValue());
 
-        for (int i = 0; i < count; i++) {
+        for (int i = 0; i < count.getValue(); i++) {
             boughtLottos.add(generateStrategy.generate());
         }
 

--- a/src/main/java/lotto/domain/LottoGenerator.java
+++ b/src/main/java/lotto/domain/LottoGenerator.java
@@ -6,6 +6,7 @@ import java.util.List;
 public class LottoGenerator {
 
     private static final LottoGenerateStrategy RANDOM_GENERATE_STRATEGY = new RandomLottoGenerateStrategy();
+    private static final String NOT_ENOUGHT_MONEY_EXCEPTION_MONEY = "금액이 부족해 구매할 수 없습니다.";
 
     private final List<Ball> balls;
 
@@ -32,6 +33,8 @@ public class LottoGenerator {
     }
 
     public BoughtResult generate(final Money money, final Count count) {
+        validate(money, count);
+
         return generate(money, count, RANDOM_GENERATE_STRATEGY);
     }
 
@@ -53,9 +56,17 @@ public class LottoGenerator {
     }
 
     public BoughtResult generateManually(final Money money, final List<Lotto> lottos) {
+        validate(money, new Count(lottos.size()));
+
         final BoughtLottos boughtLottos = new BoughtLottos(lottos);
         final Money spent = new Money(Lotto.PRICE * lottos.size());
 
         return new BoughtResult(money.subtract(spent), boughtLottos);
+    }
+
+    private void validate(final Money money, final Count count) {
+        if (money.getValue() < Lotto.PRICE * count.getValue()) {
+            throw new IllegalArgumentException(NOT_ENOUGHT_MONEY_EXCEPTION_MONEY);
+        }
     }
 }

--- a/src/main/java/lotto/domain/LottoGenerator.java
+++ b/src/main/java/lotto/domain/LottoGenerator.java
@@ -36,7 +36,7 @@ public class LottoGenerator {
         final List<Lotto> boughtLottos = new ArrayList<>();
 
         for (int i = 0; i < count; i++) {
-            boughtLottos.add(generateStrategy.generate(balls));
+            boughtLottos.add(generateStrategy.generate());
         }
 
         return new BoughtLottos(boughtLottos);

--- a/src/main/java/lotto/domain/LottoGenerator.java
+++ b/src/main/java/lotto/domain/LottoGenerator.java
@@ -27,18 +27,28 @@ public class LottoGenerator {
         return LottoGeneratorHandler.INSTANCE;
     }
 
-    public BoughtLottos generate(final Money money) {
+    public BoughtResult generate(final Money money) {
         return generate(money, RANDOM_GENERATE_STRATEGY);
     }
 
-    public BoughtLottos generate(final Money money, final LottoGenerateStrategy generateStrategy) {
+    public BoughtResult generate(final Money money, final int count) {
+        return generate(money, count, RANDOM_GENERATE_STRATEGY);
+    }
+
+    public BoughtResult generate(final Money money, final LottoGenerateStrategy generateStrategy) {
         final int count = money.getValue() / Lotto.PRICE;
+
+        return generate(money, count, generateStrategy);
+    }
+
+    public BoughtResult generate(final Money money, final int count, final LottoGenerateStrategy generateStrategy) {
         final List<Lotto> boughtLottos = new ArrayList<>();
+        final Money spent = new Money(Lotto.PRICE * count);
 
         for (int i = 0; i < count; i++) {
             boughtLottos.add(generateStrategy.generate());
         }
 
-        return new BoughtLottos(boughtLottos);
+        return new BoughtResult(money.subtract(spent), new BoughtLottos(boughtLottos));
     }
 }

--- a/src/main/java/lotto/domain/LottoGenerator.java
+++ b/src/main/java/lotto/domain/LottoGenerator.java
@@ -51,4 +51,11 @@ public class LottoGenerator {
 
         return new BoughtResult(money.subtract(spent), new BoughtLottos(boughtLottos));
     }
+
+    public BoughtResult generateManually(final Money money, final List<Lotto> lottos) {
+        final BoughtLottos boughtLottos = new BoughtLottos(lottos);
+        final Money spent = new Money(Lotto.PRICE * lottos.size());
+
+        return new BoughtResult(money.subtract(spent), boughtLottos);
+    }
 }

--- a/src/main/java/lotto/domain/Money.java
+++ b/src/main/java/lotto/domain/Money.java
@@ -2,10 +2,9 @@ package lotto.domain;
 
 public class Money {
 
-    private static final int MIN_PURCHASE_MONEY = 1_000;
-    private static final int MAX_PURCHASE_MONEY = 100_000;
+    private static final int MIN_MONEY = 0;
     private static final String MONEY_RANGE_EXCEPTION_MESSAGE =
-            "로또는 " + MIN_PURCHASE_MONEY + "원 이상 " + MAX_PURCHASE_MONEY + "원 이하만 구매할 수 있습니다";
+            "금액은 " + MIN_MONEY + "원 이상만 입력할 수 있습니다";
     private static final String NUMBER_PATTERN = "\\d+";
     private static final String NOT_NUMERIC_EXCEPTION_MESSAGE = "숫자만 입력할 수 있습니다.";
 
@@ -34,7 +33,7 @@ public class Money {
     private void validateRangeOfMoney(final String value) {
         int money = Integer.parseInt(value);
 
-        if (money < MIN_PURCHASE_MONEY || MAX_PURCHASE_MONEY < money) {
+        if (money < MIN_MONEY) {
             throw new IllegalArgumentException(MONEY_RANGE_EXCEPTION_MESSAGE);
         }
     }

--- a/src/main/java/lotto/domain/Money.java
+++ b/src/main/java/lotto/domain/Money.java
@@ -11,6 +11,10 @@ public class Money {
 
     private final int value;
 
+    public Money(final int value) {
+        this(String.valueOf(value));
+    }
+
     public Money(final String value) {
         validate(value);
         this.value = Integer.parseInt(value);
@@ -41,5 +45,24 @@ public class Money {
 
     public int getValue() {
         return this.value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Money money = (Money) o;
+
+        return value == money.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return value;
     }
 }

--- a/src/main/java/lotto/domain/Money.java
+++ b/src/main/java/lotto/domain/Money.java
@@ -35,6 +35,10 @@ public class Money {
         }
     }
 
+    public Money subtract(final Money other) {
+        return new Money(String.valueOf(value - other.getValue()));
+    }
+
     public int getValue() {
         return this.value;
     }

--- a/src/main/java/lotto/domain/RandomLottoGenerateStrategy.java
+++ b/src/main/java/lotto/domain/RandomLottoGenerateStrategy.java
@@ -3,12 +3,20 @@ package lotto.domain;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class RandomLottoGenerateStrategy implements LottoGenerateStrategy {
 
+    private static final int MIN_LOTTO_NUM = 1;
+    private static final int MAX_LOTTO_NUM = 45;
+    private static final List<Ball> LOTTO_BALLS = IntStream.range(MIN_LOTTO_NUM, MAX_LOTTO_NUM + 1)
+            .mapToObj(Ball::new)
+            .collect(Collectors.toList());
+
     @Override
-    public Lotto generate(final List<Ball> balls) {
-        List<Ball> copied = new ArrayList<>(balls);
+    public Lotto generate() {
+        List<Ball> copied = new ArrayList<>(LOTTO_BALLS);
 
         Collections.shuffle(copied);
 

--- a/src/main/java/lotto/view/LottoReader.java
+++ b/src/main/java/lotto/view/LottoReader.java
@@ -43,12 +43,12 @@ public class LottoReader {
         return new Ball(scanner.nextLine());
     }
 
-    public Count readCount() {
+    public Count readCount(final Money money) {
         System.out.println(INPUT_COUNT_MESSAGE);
 
         Scanner scanner = new Scanner(System.in);
 
-        return new Count(scanner.nextLine().replace(SPACE, EMPTY_STRING));
+        return new Count(scanner.nextLine().replace(SPACE, EMPTY_STRING), money);
     }
 
     public List<Lotto> readManualLottos(final Count count) {

--- a/src/main/java/lotto/view/LottoReader.java
+++ b/src/main/java/lotto/view/LottoReader.java
@@ -16,6 +16,8 @@ public class LottoReader {
     private static final String SPACE = " ";
     private static final String EMPTY_STRING = "";
     private static final String INPUT_MONEY_GUIDE_MESSAGE = "구입 금액을 입력해주세요.";
+    private static final String INPUT_COUNT_MESSAGE = "수동으로 구매할 로또 수를 입력해 주세요.";
+    private static final String INPUT_MANUAL_LOTTO_MESSAGE = "수동으로 구매할 번호를 입력해 주세요.";
 
     public Money readMoney() {
         System.out.println(INPUT_MONEY_GUIDE_MESSAGE);
@@ -29,15 +31,8 @@ public class LottoReader {
         System.out.println(INPUT_WINNING_LOTTO_NUMBERS_MESSAGE);
 
         Scanner scanner = new Scanner(System.in);
-        List<Ball> winningLottoBalls = new ArrayList<>();
 
-        String winningLottoNumbers = scanner.nextLine().replace(SPACE, EMPTY_STRING);
-
-        for (String winningLottoNumber : winningLottoNumbers.split(DELIMITER)) {
-            winningLottoBalls.add(new Ball(winningLottoNumber));
-        }
-
-        return new Lotto(winningLottoBalls);
+        return readLottoNumber(scanner.nextLine());
     }
 
     public Ball readBonusBall() {
@@ -49,10 +44,35 @@ public class LottoReader {
     }
 
     public Count readCount() {
-        System.out.println(INPUT_BONUS_BALL_MESSAGE);
+        System.out.println(INPUT_COUNT_MESSAGE);
 
         Scanner scanner = new Scanner(System.in);
 
         return new Count(scanner.nextLine().replace(SPACE, EMPTY_STRING));
+    }
+
+    public List<Lotto> readManualLottos(final Count count) {
+        System.out.println(INPUT_MANUAL_LOTTO_MESSAGE);
+
+        final Scanner scanner = new Scanner(System.in);
+        final List<Lotto> lottos = new ArrayList<>();
+
+        for (int i = 0; i < count.getValue(); i++) {
+            lottos.add(readLottoNumber(scanner.nextLine()));
+        }
+
+        return lottos;
+    }
+
+    private Lotto readLottoNumber(final String numbers) {
+        List<Ball> winningLottoBalls = new ArrayList<>();
+
+        String winningLottoNumbers = numbers.replace(SPACE, EMPTY_STRING);
+
+        for (String winningLottoNumber : winningLottoNumbers.split(DELIMITER)) {
+            winningLottoBalls.add(new Ball(winningLottoNumber));
+        }
+
+        return new Lotto(winningLottoBalls);
     }
 }

--- a/src/main/java/lotto/view/LottoReader.java
+++ b/src/main/java/lotto/view/LottoReader.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 import lotto.domain.Ball;
+import lotto.domain.Count;
 import lotto.domain.Lotto;
 import lotto.domain.Money;
 
@@ -45,5 +46,13 @@ public class LottoReader {
         Scanner scanner = new Scanner(System.in);
 
         return new Ball(scanner.nextLine());
+    }
+
+    public Count readCount() {
+        System.out.println(INPUT_BONUS_BALL_MESSAGE);
+
+        Scanner scanner = new Scanner(System.in);
+
+        return new Count(scanner.nextLine().replace(SPACE, EMPTY_STRING));
     }
 }

--- a/src/main/java/lotto/view/LottoWriter.java
+++ b/src/main/java/lotto/view/LottoWriter.java
@@ -42,7 +42,7 @@ public class LottoWriter {
         Collections.reverse(criterias);
         printStatistics(winningStatistics, criterias);
 
-        final double earningRate = Math.floor(winningStatistics.getEarningRate() / 100) * 100;
+        final double earningRate = Math.floor(winningStatistics.getEarningRate() * 100) / 100;
         printEarningRate(earningRate);
     }
 

--- a/src/test/java/lotto/domain/BoughtLottosTest.java
+++ b/src/test/java/lotto/domain/BoughtLottosTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-public class BoughtLottosTest {
+class BoughtLottosTest {
 
     @Test
     @DisplayName("구입한 로또 정상 생성 입력 테스트")
@@ -32,6 +32,26 @@ public class BoughtLottosTest {
 
         /* when & then */
         assertThat(boughtLottos.getCount()).isEqualTo(lottos.size());
+    }
+
+    @Test
+    @DisplayName("로또 병합 테스트")
+    void boughtLottos_merge() {
+        /* given */
+        List<Lotto> lottos1 = new ArrayList<>();
+        lottos1.add(new Lotto(LottoTest.getBalls("1", "2", "3", "4", "5", "6")));
+        lottos1.add(new Lotto(LottoTest.getBalls("1", "2", "3", "4", "5", "6")));
+        BoughtLottos boughtLottos1 = new BoughtLottos(lottos1);
+
+        List<Lotto> lottos2 = new ArrayList<>();
+        lottos2.add(new Lotto(LottoTest.getBalls("1", "2", "3", "4", "5", "6")));
+        lottos2.add(new Lotto(LottoTest.getBalls("1", "2", "3", "4", "5", "6")));
+        BoughtLottos boughtLottos2 = new BoughtLottos(lottos2);
+
+        BoughtLottos merged = BoughtLottos.merge(boughtLottos1, boughtLottos2);
+
+        /* when & then */
+        assertThat(merged.getCount()).isEqualTo(boughtLottos1.getCount() + boughtLottos2.getCount());
     }
 
     @Test

--- a/src/test/java/lotto/domain/CountTest.java
+++ b/src/test/java/lotto/domain/CountTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -28,5 +29,13 @@ class CountTest {
     @ValueSource(strings = {"1+2", "2-1", "1,000", "0.1"})
     void count_notNumericCount(final String count) {
         assertThrows(IllegalArgumentException.class, () -> new Count(count));
+    }
+
+    @DisplayName("구매 가능 금액 이상으로 수를 입력하는 테스트")
+    @Test
+    void count_notEnoughMoney() {
+        Money money = new Money(0);
+
+        assertThrows(IllegalArgumentException.class, () -> new Count("1", money));
     }
 }

--- a/src/test/java/lotto/domain/CountTest.java
+++ b/src/test/java/lotto/domain/CountTest.java
@@ -10,16 +10,16 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class CountTest {
 
-    @DisplayName("1 이상의 수를 입력하는 테스트")
+    @DisplayName("0 이상의 수를 입력하는 테스트")
     @ParameterizedTest
-    @ValueSource(strings = {"1", "5", "10", "15"})
+    @ValueSource(strings = {"0", "1", "5", "10", "15"})
     void count_create(final String count) {
         assertDoesNotThrow(() -> new Count(count));
     }
 
-    @DisplayName("0 이하의 수를 입력하는 테스트")
+    @DisplayName("0 미만의 수를 입력하는 테스트")
     @ParameterizedTest
-    @ValueSource(strings = {"-100", "-5", "-1", "0"})
+    @ValueSource(strings = {"-100", "-5", "-1"})
     void count_notPositiveCount(final String count) {
         assertThrows(IllegalArgumentException.class, () -> new Count(count));
     }

--- a/src/test/java/lotto/domain/CountTest.java
+++ b/src/test/java/lotto/domain/CountTest.java
@@ -1,0 +1,32 @@
+package lotto.domain;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class CountTest {
+
+    @DisplayName("1 이상의 수를 입력하는 테스트")
+    @ParameterizedTest
+    @ValueSource(strings = {"1", "5", "10", "15"})
+    void count_create(final String count) {
+        assertDoesNotThrow(() -> new Count(count));
+    }
+
+    @DisplayName("0 이하의 수를 입력하는 테스트")
+    @ParameterizedTest
+    @ValueSource(strings = {"-100", "-5", "-1", "0"})
+    void count_notPositiveCount(final String count) {
+        assertThrows(IllegalArgumentException.class, () -> new Count(count));
+    }
+
+    @DisplayName("수 이외의 문자를 입력하는 테스트")
+    @ParameterizedTest
+    @ValueSource(strings = {"1+2", "2-1", "1,000", "0.1"})
+    void count_notNumericCount(final String count) {
+        assertThrows(IllegalArgumentException.class, () -> new Count(count));
+    }
+}

--- a/src/test/java/lotto/domain/LottoGeneratorTest.java
+++ b/src/test/java/lotto/domain/LottoGeneratorTest.java
@@ -2,6 +2,8 @@ package lotto.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -74,5 +76,25 @@ class LottoGeneratorTest {
                 new Lotto(LottoTest.getBalls("1", "2", "3", "4", "5", "6")),
                 new Lotto(LottoTest.getBalls("7", "8", "9", "10", "11", "12"))
         );
+    }
+
+    @Test
+    @DisplayName("로또를 받은 대로 생성하는지 테스트")
+    void lottoGenerator_generateManually() {
+        /* given */
+        Money money = new Money(3000);
+        List<Lotto> lottos = new ArrayList<>(List.of(
+                new Lotto(LottoTest.getBalls("1", "2", "3", "4", "5", "6")),
+                new Lotto(LottoTest.getBalls("1", "3", "5", "7", "9", "11")),
+                new Lotto(LottoTest.getBalls("2", "4", "6", "8", "10", "12"))));
+        LottoGenerator lottoGenerator = LottoGenerator.getInstance();
+
+        /* when */
+        BoughtResult boughtResult = lottoGenerator.generateManually(money, lottos);
+        BoughtLottos boughtLottos = boughtResult.getBoughtLottos();
+
+        /* then */
+        assertThat(boughtLottos.getLottos()).hasSize(3);
+        assertThat(boughtLottos.getLottos()).isEqualTo(lottos);
     }
 }

--- a/src/test/java/lotto/domain/LottoGeneratorTest.java
+++ b/src/test/java/lotto/domain/LottoGeneratorTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class LottoGeneratorTest {
+class LottoGeneratorTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"10000", "9999", "100000"})
@@ -18,10 +18,44 @@ public class LottoGeneratorTest {
         LottoGenerator lottoGenerator = LottoGenerator.getInstance();
 
         /* when */
-        BoughtLottos boughtLottos = lottoGenerator.generate(money);
+        BoughtResult boughtResult = lottoGenerator.generate(money);
+        BoughtLottos boughtLottos = boughtResult.getBoughtLottos();
 
         /* then */
         assertThat(boughtLottos.getLottos()).hasSize(Integer.parseInt(value) / Lotto.PRICE);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 5, 10})
+    @DisplayName("받은 개수만큼 로또를 생성하는지 테스트")
+    void lottoGenerator_countToLotto(final int count) {
+        /* given */
+        final Money money = new Money(100_000);
+        LottoGenerator lottoGenerator = LottoGenerator.getInstance();
+
+        /* when */
+        BoughtResult boughtResult = lottoGenerator.generate(money, count);
+        BoughtLottos boughtLottos = boughtResult.getBoughtLottos();
+
+        /* then */
+        assertThat(boughtLottos.getLottos()).hasSize(count);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 5, 10})
+    @DisplayName("로또를 생성하고 거스름돈을 제대로 반환하는지 테스트")
+    void lottoGenerator_change(final int count) {
+        /* given */
+        final Money money = new Money(100_000);
+        final Money expected = new Money(100_000 - Lotto.PRICE * count);
+        LottoGenerator lottoGenerator = LottoGenerator.getInstance();
+
+        /* when */
+        BoughtResult boughtResult = lottoGenerator.generate(money, count);
+        Money change = boughtResult.getChange();
+
+        /* then */
+        assertThat(change).isEqualTo(expected);
     }
 
     @Test
@@ -32,7 +66,8 @@ public class LottoGeneratorTest {
 
         /* when */
         final LottoGenerator lottoGenerator = LottoGenerator.getInstance();
-        BoughtLottos boughtLottos = lottoGenerator.generate(money, new SequenceLottoGenerateStrategy());
+        BoughtResult boughtResult = lottoGenerator.generate(money, new SequenceLottoGenerateStrategy());
+        BoughtLottos boughtLottos = boughtResult.getBoughtLottos();
 
         /* then */
         assertThat(boughtLottos.getLottos()).containsExactlyInAnyOrder(

--- a/src/test/java/lotto/domain/LottoGeneratorTest.java
+++ b/src/test/java/lotto/domain/LottoGeneratorTest.java
@@ -34,7 +34,7 @@ class LottoGeneratorTest {
         LottoGenerator lottoGenerator = LottoGenerator.getInstance();
 
         /* when */
-        BoughtResult boughtResult = lottoGenerator.generate(money, count);
+        BoughtResult boughtResult = lottoGenerator.generate(money, new Count(count));
         BoughtLottos boughtLottos = boughtResult.getBoughtLottos();
 
         /* then */
@@ -51,7 +51,7 @@ class LottoGeneratorTest {
         LottoGenerator lottoGenerator = LottoGenerator.getInstance();
 
         /* when */
-        BoughtResult boughtResult = lottoGenerator.generate(money, count);
+        BoughtResult boughtResult = lottoGenerator.generate(money, new Count(count));
         Money change = boughtResult.getChange();
 
         /* then */

--- a/src/test/java/lotto/domain/MoneyTest.java
+++ b/src/test/java/lotto/domain/MoneyTest.java
@@ -2,12 +2,14 @@ package lotto.domain;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class MoneyTest {
+class MoneyTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"99999", "1000", "1001", "100000"})
@@ -31,5 +33,19 @@ public class MoneyTest {
     void money_notNumericInput(final String value) {
         /* given & when & then */
         assertThatThrownBy(() -> new Money(value)).isExactlyInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("돈 차감 테스트")
+    void money_subtract() {
+        // given
+        final Money money1 = new Money("10000");
+        final Money money2 = new Money("4000");
+
+        // when
+        final Money subtracted = money1.subtract(money2);
+
+        // then
+        assertEquals(6000, subtracted.getValue());
     }
 }

--- a/src/test/java/lotto/domain/MoneyTest.java
+++ b/src/test/java/lotto/domain/MoneyTest.java
@@ -20,8 +20,8 @@ class MoneyTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"999", "100001"})
-    @DisplayName("범위 초과 구입 금액 생성 테스트")
+    @ValueSource(strings = {"-1000", "-1"})
+    @DisplayName("범위 초과 금액 생성 테스트")
     void money_inputOutOfRangeMoney(final String value) {
         /* given & when & then */
         assertThatThrownBy(() -> new Money(value)).isExactlyInstanceOf(IllegalArgumentException.class);

--- a/src/test/java/lotto/domain/SequenceLottoGenerateStrategy.java
+++ b/src/test/java/lotto/domain/SequenceLottoGenerateStrategy.java
@@ -1,18 +1,26 @@
 package lotto.domain;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class SequenceLottoGenerateStrategy implements LottoGenerateStrategy {
+
+    private static final int MIN_LOTTO_NUM = 1;
+    private static final int MAX_LOTTO_NUM = 45;
+    private static final List<Ball> LOTTO_BALLS = IntStream.range(MIN_LOTTO_NUM, MAX_LOTTO_NUM + 1)
+            .mapToObj(Ball::new)
+            .collect(Collectors.toList());
 
     private int sequenceStartIndex = 0;
 
     @Override
-    public Lotto generate(final List<Ball> balls) {
+    public Lotto generate() {
         if (sequenceStartIndex + Lotto.SIZE > Ball.MAX_NUMBER) {
             sequenceStartIndex = 0;
         }
 
-        Lotto lotto = new Lotto(balls.subList(sequenceStartIndex, sequenceStartIndex + Lotto.SIZE));
+        Lotto lotto = new Lotto(LOTTO_BALLS.subList(sequenceStartIndex, sequenceStartIndex + Lotto.SIZE));
 
         sequenceStartIndex += Lotto.SIZE;
 


### PR DESCRIPTION
안녕하세요, 리뷰어님!

우선 로또 구현 두 번째 단계 PR을 너무 늦게 드려 죄송합니다..!

변경사항은 크게 다음과 같습니다!
1. 구매 개수를 담기 위한 Count 클래스 생성
2. 확장성을 위해 자동 로또 구매 시 수동 로또처럼 개수를 설정해 구매할 수 있도록 수정
3. 전략마다 사용하는 Ball의 범위가 달라질 수 있으므로, 랜덤으로 뽑을 Ball list를 RandomLottoGenerateStrategy가 갖도록 수정 (기존 LottoGenerator)
4. 자동 로또까지 모두 구매한 뒤, 수동 로또와 병합하여 기존 로직 수정을 최대한 회피
5. 거스름돈을 구하기 위해 Money에 차감 메서드 추가

PR을 너무 늦게 드린 점 다시 한 번 사과드립니다..

시간 내어 읽어주셔서 감사합니다!